### PR TITLE
Have our fork use it's own module name

### DIFF
--- a/amberc/cli.go
+++ b/amberc/cli.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	amber "pendo.io/forks/amber"
+	"github.com/pendo-io/amber"
 )
 
 var prettyPrint bool

--- a/compiler.go
+++ b/compiler.go
@@ -11,7 +11,7 @@ import (
 	"html/template"
 	"io"
 	"path/filepath"
-	"pendo.io/forks/amber/parser"
+	"github.com/pendo-io/amber/parser"
 	"reflect"
 	"regexp"
 	"strconv"


### PR DESCRIPTION
Why?

When this is pulled in from pendo-appengine, go will complain that the module does not match the path. A lot of our packages in goexternal are our forks, "disguised" as upstream.